### PR TITLE
feat: update status output

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use clap::{Parser, Subcommand, ValueEnum};
 use serde::Serialize;
 
@@ -109,6 +111,15 @@ impl From<bool> for OnOff {
             OnOff::On
         } else {
             OnOff::Off
+        }
+    }
+}
+
+impl fmt::Display for OnOff {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            OnOff::On => write!(f, "on"),
+            OnOff::Off => write!(f, "off"),
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,7 +43,7 @@ fn main() {
         Some(Commands::Version) => mpd.version(),
 
         Some(Commands::Status) => mpd.current_status(args.format),
-        None => Ok(None),
+        None => mpd.current_status(args.format),
     };
 
     match result {


### PR DESCRIPTION
- include fields to match `mpc`
- update `text` format
- make `status` default command (redux)

Resolves #26
