### PR TITLE
feat: add support for `stdin` for `add`

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -26,7 +26,7 @@ pub(crate) enum Commands {
     //
     /// Add a song to the queue at the given path (or dir '/')
     #[command()]
-    Add { path: String },
+    Add { path: Option<String> },
     /// Remove all but the current song from the queue
     #[command()]
     Crop,


### PR DESCRIPTION
The following variants now work:

```bash
mp-cli add U2
```

or

```bash
echo "U2" | mp-cli add
```

Resolves #34
