### PR TITLE
ci: fix CD script

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -23,7 +23,7 @@ defaults:
 jobs:
   upload-assets:
     name: ${{ matrix.target }}
-    if: github.repository_owner == 'johnallen3d' && startsWith(github.event.release.name, 'v')
+    if: github.repository_owner == 'johnallen3d' && startsWith(github.event.release.name, 'mp-cli-v')
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:


### PR DESCRIPTION
This project was migrated to a workspace project with multiple crates. It looks like that has an impact on how `release-plz` names the releases it creates (eg. now prefix with package name).
