### PR TITLE
ci: fix workspace dependencies

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -9,5 +9,5 @@ repository.workspace = true
 
 [dependencies]
 clap = { version = "4.4.13", features = ["derive"] }
-mpd-easy = { path = "../lib" }
+mpd-easy = { path = "../lib", version = "0.1.6" }
 serde = { workspace = true }


### PR DESCRIPTION
Cargo will not publish a crate that depends on a crate with a local path (and not a version).

https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#specifying-path-dependencies
