### PR TITLE
docs: fix README for `cli` crate

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -6,6 +6,7 @@ description = "A Music Player Daemon (MPD) CLI client implemented in Rust."
 homepage.workspace = true
 license.workspace = true
 repository.workspace = true
+readme = "../README.md"
 
 [dependencies]
 clap = { version = "4.4.13", features = ["derive"] }


### PR DESCRIPTION
Hopefully this will fix the rendering on crates.io
